### PR TITLE
Add additional DB retrieve endpoints

### DIFF
--- a/handler.js
+++ b/handler.js
@@ -22,7 +22,9 @@ const getTag = async (req, res) => {
   await client.connect()
   const database = client.db('OBJKTs-DB')
   const objkts = database.collection('metadata')
-  let r = await objkts.find({ tags : { $all : [ req.query.tag ]}})
+  let r = await objkts
+    .find({ tags : { $all : [ req.query.tag ] } })
+    .collation({locale: 'en', strength: 1})
   res.json({
       result : await r.toArray()
   })


### PR DESCRIPTION
* Make tag search case-insensitive

`GET localhost:3002/tag?tag=CAT` and `GET localhost:3002/tag?tag=cat` now return same resultset

* `GET unique_tags`

```
{
    "result": [
        {
            "_id": {
                "tag": "",
                "lower": ""
            },
            "count": 3890
        },
        {
            "_id": {
                "tag": "art",
                "lower": "art"
            },
            "count": 3663
        },
        {
            "_id": {
                "tag": "generative",
                "lower": "generative"
            },
            "count": 2636
        },
        {
            "_id": {
                "tag": "abstract",
                "lower": "abstract"
            },
            "count": 2561
        },

```

* `GET owners`

```
GET localhost:4002/owners?objkt_id=56969

{
    "KT1Hkg5qeNhfwpKW4fXvq7HGZB9z2EnmCCA9": 92,
    "tz1KxARuCbAoiGGesnQjr2pvZa7CzJR7V9D7": 1,
    "tz1L2yuYQMNayroPcnrEZ9YytP4rwgj6FWZ1": 1,
    "tz1Lid7agf4g4GrpWf7xuoAyqCbUxXUFYZBJ": 1,
...
}
